### PR TITLE
Changing suppliers select to bootstrap dropdown

### DIFF
--- a/views/templates/_partials/supplier_form.tpl
+++ b/views/templates/_partials/supplier_form.tpl
@@ -31,7 +31,7 @@
     aria-haspopup="true"
     aria-expanded="false">
     {l s='All suppliers' d='Modules.Supplierlist.Shop'}
-    <i class="material-icons float-xs-right">&#xE5C5;</i>
+    <i class="material-icons float-xs-right">arrow_drop_down</i>
   </button>
   <div class="dropdown-menu">
     {foreach from=$suppliers item=supplier}

--- a/views/templates/_partials/supplier_form.tpl
+++ b/views/templates/_partials/supplier_form.tpl
@@ -23,11 +23,25 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 
-<form action="#">
-  <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
-    <option value="">{l s='All suppliers' d='Modules.Supplierlist.Shop'}</option>
+<div class="suppliers-sort dropdown">
+  <button
+    class="btn-unstyle select-title"
+    rel="nofollow"
+    data-toggle="dropdown"
+    aria-haspopup="true"
+    aria-expanded="false">
+    {l s='All suppliers' d='Modules.Supplierlist.Shop'}
+    <i class="material-icons float-xs-right">&#xE5C5;</i>
+  </button>
+  <div class="dropdown-menu">
     {foreach from=$suppliers item=supplier}
-      <option value="{$supplier['link']}">{$supplier['name']}</option>
+      <a
+        rel="nofollow"
+        href="{$supplier['link']}"
+        class="select-list js-search-link"
+      >
+        {$supplier['name']}
+      </a>
     {/foreach}
-  </select>
-</form>
+  </div>
+</div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The select of supplier module on category page is ugly, let's use a bootstrap dropdown we already use on this page
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9669 
| How to test?  | Install the ps_supplierlist module, then change the configuration to dropdown instead of plain text

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16526)
<!-- Reviewable:end -->
