### PR TITLE
Does not load content if PS_DISPLAY_SUPPLIERS is set to false

### DIFF
--- a/ps_supplierlist.php
+++ b/ps_supplierlist.php
@@ -247,6 +247,10 @@ class Ps_Supplierlist extends Module implements WidgetInterface
 
     public function renderWidget($hookName, array $configuration)
     {
+        if (!Configuration::get('PS_DISPLAY_SUPPLIERS')) {
+            return;
+        }
+
         $cacheId = $this->getCacheId();
         $isCached = $this->isCached($this->templateFile, $cacheId);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If the PS_DISPLAY_SUPPLIERS is set to false, every link to the supplier page will redirect into a 404 page. There is no need to list them with links if the visitor could not see the supplier page.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | See that suppliers list is not anymore into the left column.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
