### PR TITLE
Check if suppliers are enabled

### DIFF
--- a/ps_supplierlist.php
+++ b/ps_supplierlist.php
@@ -247,6 +247,12 @@ class Ps_Supplierlist extends Module implements WidgetInterface
 
     public function renderWidget($hookName, array $configuration)
     {
+        // If supplier listing is disabled in backoffice, we won't show this block.
+        // Customers would be pointed to 404 anyway.
+        if (!Configuration::get('PS_DISPLAY_SUPPLIERS')) {
+            return;
+        }
+
         $cacheId = $this->getCacheId();
         $isCached = $this->isCached($this->templateFile, $cacheId);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Check if suppliers are enabled when rendering the block.
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#33361
| How to test?  | Check that this module is hooked and displayed somewhere. Disable suppliers in BO > Shop settings > General. See that this module disappears from FO.